### PR TITLE
关于logback的版本漏洞修复 #488

### DIFF
--- a/kafka-manager-web/pom.xml
+++ b/kafka-manager-web/pom.xml
@@ -84,6 +84,11 @@
             <version>${spring.boot.version}</version>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
             <version>${spring.boot.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <tomcat.version>8.5.72</tomcat.version>
         <log4j2.version>2.16.0</log4j2.version>
         <maven-assembly-plugin.version>3.0.0</maven-assembly-plugin.version>
+        <logback.version>1.2.9</logback.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
移除原logback-1.2.3
更新为:1.2.9
关于logback的漏洞:[详见这里](https://nvd.nist.gov/vuln/detail/CVE-2021-42550)